### PR TITLE
added resources for automatic inclusion of scripts in html upon install

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,6 +3,10 @@
   "main": "angular-otobox.js",
   "version": "0.2.0",
   "homepage": "https://github.com/alihaghighatkhah/angular-otobox",
+  "main": [
+    "otobox.js", 
+    "angular-otobox.js"
+  ],
   "authors": [
     "ali haghighatkhah <alihaghighatkhah@yahoo.com>"
   ],


### PR DESCRIPTION
when using 'bower install' or 'grunt serve' the resources specified in 'main' will be automatically included into the bower reserved spot for script inclusion.

In fact without this change, 'grunt serve' will automatically remove them each time which is annoying.

i.e. 

<!-- build:js scripts/vendor.js -->

<!-- bower:js -->

<script src="...other scripts..."></script>

<script src="bower_components/angular-otobox/otobox.js"></script>

<script src="bower_components/angular-otobox/angular-otobox.js"></script>

<!-- endbower -->

<!-- endbuild -->
